### PR TITLE
dp-desktop-app update pom.xml to version 1.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.ospreydcs</groupId>
     <artifactId>dp-desktop-app</artifactId>
     <packaging>jar</packaging>
-    <version>1.14.0</version>
+    <version>1.15.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
@@ -19,8 +19,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <main.basedir>${project.basedir}</main.basedir>
-        <dp-grpc.version>1.14.0</dp-grpc.version>
-        <dp-service.version>1.14.0</dp-service.version>
+        <dp-grpc.version>1.15.0</dp-grpc.version>
+        <dp-service.version>1.15.0</dp-service.version>
         <mongodb.version>5.4.0</mongodb.version>
         <log4j-version>2.23.1</log4j-version>
         <snakeyaml.version>2.2</snakeyaml.version>


### PR DESCRIPTION
## Summary
- Bump project version from 1.14.0 to 1.15.0
- Update `dp-grpc.version` and `dp-service.version` to 1.15.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)